### PR TITLE
Fix typo in document

### DIFF
--- a/features/1_developer.md
+++ b/features/1_developer.md
@@ -32,7 +32,7 @@ docker-compose up --build
 - Build Tool : Gradle 6.x
 - Git : [https://github.com/fosslight/fosslight][src]
 - IDE : [Spring Tool Suite][spring]
-    - [lombock][lb] 설치 필요
+    - [lombok][lb] 설치 필요
 - Project Character Set: UTF-8
 
 ### 다운로드 & 설치

--- a/started/2_try/2_oss.md
+++ b/started/2_try/2_oss.md
@@ -45,7 +45,7 @@ OSS List의 OSS Name Column 내 cell을 클릭하면 상세정보를 확인할 �
 ### Download Location 
 - Open Source를 다운로드 받을 수 있는 URL이 Link로 표시되며, 클릭 시 해당 사이트로 이동하거나 파일을 다운로드 받을 수 있습니다.
 
-### Hoempage 
+### Homepage 
 - Open Source 공식 Site가 있으면, 로 표시되며 클릭 시 해당 사이트로  이동합니다.
 - 아이콘에 마우스 오버 시 상세주소를 확인할 수 있습니다.
 


### PR DESCRIPTION
I found a typo in the guide document

Hoempage -> Homepage
lombock -> lombok

Thanks!