### PR TITLE
update guide for removing the options

### DIFF
--- a/scanner/6_android.md
+++ b/scanner/6_android.md
@@ -76,9 +76,7 @@ fosslight_android 명령어를 실행합니다.
             -m                             Analyze the source code for the path where the license could not be found.
             -e <path1> <path2..>           Path to exclude from source analysis.(Pattern matching is available)
             -p                             Check files that should not be included in the Packaging file.
-            -f                             Print result of Find Command for binary that can not find Source Code Path.
-            -t                             Collect NOTICE for binaries that are not added to NOTICE.html.
-            -d                             Divide needtoadd-notice.html by binary.
+            -f                             Print result of Find Command for binary that can not find Source Code Path.                        
             -i                             Disable the function to automatically convert OSS names based on AOSP.
             -r <result.txt>                result.txt file with a list of binaries to remove.
     ``` 
@@ -126,82 +124,15 @@ fosslight_android 명령어를 실행합니다.
 ## 🚗 추가 기능
 ---
 하기 옵션을 통해 부가 기능을 활용할 수 있습니다.
-- Option: -b, -n, -c : NOTICE.html에 Binary 이름이 포함되었는지 여부를 확인합니다.
 - Option: -p : Packaging 파일에 포함되지 않아야 하는 파일을 확인합니다.
 - Option: -f : Source Code Path를 찾지 못하는 binary에 대하여 Find Command 실행 결과를 출력해줍니다.
-- Option: -t : NOTICE가 Source Code Path에 있음에도 NOTICE.html에 추가되지 않는 binary에 대하여 NOTICE를 취합합니다.
 - Option: -i : Android reference 의 repository기준으로 OSS Name의 자동 출력을 비활성화합니다.
-- Option: -d : needtoadd-notice.html파일을 Binary별로 분할합니다.
 - Option: -r : 특정 binary가 FOSSLight Report에서 중복되는것을 제거합니다. Android native와 vendor가 분리되어 build되는 구조에서 사용하는 옵션으로 중복으로 포함되는 Binary를 제거합니다. vendor에 대한 FOSSLight Android 실행시 -r 옵션으로 android native 결과 생성되는 result_*.txt 파일을 parameter로 추가합니다.
 - Option: -m : License가 빈칸인 부분에 대해 자동으로 Source path 내 Source code 분석(소스 파일 내 License text 기반 License 검출)을 실행하여 License 값을 채워줍니다. (그러나 분석에 시간이 오래 걸립니다. Android native에서 44개 Path기준 약 35분 소요)
 
 
 ---
 
-### -b, -n, -c: NOTICE.html에 Binary 이름 포함 여부 확인
-#### (1) OSS가 사용 된 경우 ( NOTICE.html이 ok 또는 ok(NA)인 경우)
-
-OSS 보고서 BIN(Android) sheet내 NOTICE.html column의 값이 ok 또는 ok(NA)라면, 그 Binary 이름은 NOTICE.html에 포함되어 있어야 합니다.
-
-#### 실행방법
-
-Binary 이름이 NOTICE.html에 포함되었는지 확인하는 방법은 다음과 같습니다.
-1. NOTICE.html 의 값을 ok, ok(NA)만 조회합니다.
-2. 이제 Binary Name column에서 모든 항목을 선택하여 Copy합니다.
-3. Linux 환경에서 binary.txt 라는 파일을 vi editor를 이용하여 생성합니다.
-    ```
-    (venv)$ vi binary.txt
-    ```
-4. 그리고, 2에서 copy한 내용을 binary.txt에 붙여넣고 저장합니다.
-5. NOTICE.html을 binary.txt와 같은 directory에 위치시킵니다.
-    ```
-    (venv)$ ls
-    binary.txt  NOTICE.html
-    ```
-
-6. "-c" option을 사용하여 결과를 추출합니다. 이때, -c option parameter로 ok 항목에 대한 체크사항이므로 ok라고 입력합니다.
-    ```
-    (command)
-    (venv)$ fosslight_android -b [binary.txt] -n [NOTICE.html] -c [ok|nok]
-    
-    (ex)
-    (venv)$ fosslight_android -b binary.txt -n NOTICE.html -c ok
-    ```
-
-7. NOTICE 파일이 여러개일 경우 ,로 구분하여 작성합니다.
-
-   ex) NOTICE파일이 NOTICE.xml,NOTICE_VENDOR.xml,NOTICE_PRODUCT.xml,NOTICE_PRODUCT_SERVICES.xml 인 경우:
-   ```
-   (venv)$ fosslight_android -b binary.txt -n NOTICE.xml,NOTICE_VENDOR.xml,NOTICE_PRODUCT.xml,NOTICE_PRODUCT_SERVICES.xml  -c ok
-   ```
-
-8. 어떤 binary가 NOTICE.html내 포함되어 있지 않은지 확인합니다.
- 
-   - result.txt 파일을 열면, nok 항목인 binary 목록이 출력됩니다.
-   - 해당 binary는 OSS 보고서 내 NOTICE.html column에는 ok 또는 ok(NA)로 되어 있음에도 NOTICE.html에 포함되어 있지 않은 것을 확인할 수 있습니다.
-   - (warning) NOTICE.html이 ok 또는 ok(NA)인 binary의 경우, 모두 NOTICE.html에 표시되어야 하므로 위 result.txt 파일 내 nok로 표기되는 binary가 없어야 합니다.  
-<br>  
-
-#### (2) OSS 사용되지 않은 경우 ( NOTICE.html이 nok 또는 nok(NA)인 경우 )  
-
-OSS가 사용되지 않았다고 명시한 binary의 경우, 그 이름이 NOTICE.html에 포함되서는 안됩니다.
-Binary 이름이 NOTICE.html에 포함되지 않았는지 확인 방법은 다음과 같습니다.
-
-1. NOTICE.html column에서 nok, nok(NA)만 조회 합니다.
-2. 위의 (1)번 내 2부터 5까지를 참고하여 실행합니다. 이때, -c option parameter로 nok 항목에 대한 체크사항이므로 nok라고 입력합니다.
-   ```
-   (command)
-   (venv)$ fosslight_android -b [binary.txt] -n [NOTICE.html] -c [ok|nok]
-  
-   (ex)
-   (venv)$ fosslight_android -b binary.txt -n NOTICE.html -c nok
-   ```
-
-3. 추출한 결과에서 어떤 binary가 NOTICE.html에 포함되어 있는지 확인합니다.
-   result.txt 파일을 열면, OSS 보고서에 OSS가 사용되지 않은 것으로 명시되었음에도 NOTICE.html에 포함된 binary를 확인할 수 있습니다.
-   (warning) NOTICE.html이 nok 또는 nok(NA)인 경우, NOTICE.html에 포함되면 안 되므로, 위 result.txt 에 ok로 출력되는 binary가 있어서는 안 됩니다
-<br>
-<br>
 
 ### -p: Packaging 파일에 포함되지 않아야 하는 파일 확인
 공개할 Source Code 취합시, 포함되지 말아야 하는 파일 이름, 확장자, 디렉토리를 체크합니다.  
@@ -298,38 +229,6 @@ Source Code Path를 찾지 못하는 Binary에 대하여 Android의 Source Path�
 2. 단, Source Code Path를 찾지 못하는 Binary가 없을 경우 해당 파일은 생성되지 않습니다.
 <br>
 <br>
-
-### -t: NOTICE.html에 추가되지 않는 binary에 대하여 NOTICE를 취합
-Source Code Path에 NOTICE가 있음에도 최종 제품에 탑재되는 NOTICE(NOTICE.html)에 포함되지 않는 Binary에 대하여 NOTICE를 취합한 파일을 생성합니다.
-
-#### 실행방법
-1. -t 옵션을 추가하여 실행합니다.
-    ```commandline
-    (venv)$ fosslight_android -s [android source path] -a [build log file name] -t
- 
-    ex
-    (venv)$ fosslight_android -s /home/soim/android/source -a android.log -t
-    ```
-
-#### 결과 확인        
-1. Source Code Path에 NOTICE가 있음에도 최종 제품에 탑재되는 NOTICE(NOTICE.html)에 포함되지 않는 Binary의 NOTICE를 취합하여 'needtoadd-notice.html'이라는 파일로 생성됩니다.
-2. 단, 위 사항에 해당하는 Binary가 없을 경우 해당 파일은 생성되지 않습니다.
-3. 생성된 needtoadd-notice.html는 별도 생성한 OSS 고지문의 NOTICE.html 삽입 방법을 통하여 최종 제품에 탑재되는 NOTICE.html에 포함시킵니다.
-<br>
-<br>
-
-
-### -d: -t 옵션으로 생성한 needtoadd-notice.html파일을 Binary별 분할
-needtoadd-notice.html 파일을 읽어 Binary 별 license text 파일을 생성합니다. 이 기능은 xml/html 포맷 무관하게 Android의 OSS Notice 파일에 needtoadd-notice.html 파일을 추가할 때 활용합니다. 하기와 같이 폴더와 파일을 생성하고 License text를 해당 파일에 출력합니다.
-
-1. Binary name: system/core/local_bin.jar 인 경우, 
-    - NOTICE_FILES
-    - ---system
-    - -----------core
-    - ------------------local_bin.jar.txt
-<br>
-<br>
-
 
 
 ### -i: OSS Name 자동 완성 기능 끄기


### PR DESCRIPTION
## Description
Remove some options

[Option: -b, -n, -c]
Checked whether the Binary name is included in NOTICE.html.
This step is unnecessary as the inclusion of notice is checked through the FL Hub.

[Option: -t]
For binaries where NOTICE is located in the source code path but not added to NOTICE.html, NOTICE is aggregated.
This can be handled using the Supplement feature of FL Hub.

[Option: -d]
The needtoadd-notice.html file is divided by binary.
This can also be managed using the Supplement feature of FL Hub.



## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
